### PR TITLE
sleep 10 seconds before wait_for_sshd

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -97,6 +97,7 @@ module Kitchen
         if config[:no_ssh_tcp_check]
           wait_for_container(state)
         else
+          sleep 10
           wait_for_sshd(state[:hostname], nil, :port => state[:port])
         end
       end


### PR DESCRIPTION
https://github.com/peterabbott/kitchen-docker/issues/3
To avoid ssh connection error, sleep 10 seconds before call **wait_for_sshd** function
