### PR TITLE
Minor upgrades

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -97,6 +97,7 @@ module Kitchen
         if config[:no_ssh_tcp_check]
           wait_for_container(state)
         else
+          sleep 1
           wait_for_sshd(state[:hostname], nil, :port => state[:port])
         end
       end


### PR DESCRIPTION
To avoid ssh connection errors (https://github.com/peterabbott/kitchen-docker/issues/3), sleep 1 second before call **wait_for_sshd**
Reduce the number of intermediate containers to speed up converge phase
